### PR TITLE
Export missing signature types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,14 @@ fn my_module(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<group_sessions::InboundGroupSession>()?;
 
     m.add_class::<types::Ed25519PublicKey>()?;
+    m.add_class::<types::Ed25519Signature>()?;
     m.add_class::<types::Curve25519PublicKey>()?;
 
     m.add("KeyException", py.get_type_bound::<KeyException>())?;
+    m.add(
+        "SignatureException",
+        py.get_type_bound::<SignatureException>(),
+    )?;
     m.add("DecodeException", py.get_type_bound::<DecodeException>())?;
     m.add(
         "LibolmPickleException",

--- a/tests/account_test.py
+++ b/tests/account_test.py
@@ -1,7 +1,7 @@
 import vodozemac
 import pytest
 
-from vodozemac import Account, PickleException
+from vodozemac import Account, PickleException, SignatureException
 
 PICKLE_KEY = b"DEFAULT_PICKLE_KEY_1234567890___"
 
@@ -54,3 +54,11 @@ class TestClass(object):
 
         alice.mark_keys_as_published()
         assert not alice.one_time_keys
+
+    def test_signing(self):
+        alice = Account()
+        signature = alice.sign("This is a test")
+
+        alice.ed25519_key.verify_signature("This is a test", signature)
+        with pytest.raises(SignatureException):
+            alice.ed25519_key.verify_signature("This should fail", signature)


### PR DESCRIPTION
#2 introduced some types, but didn't export them.  This PR adds those types, and adds a test.